### PR TITLE
bug/extract-text-from-pdf-ocr-fix-for-upper-case-file-format

### DIFF
--- a/extract-text-from-pdf-ocr/scripts/extract_text_from_pdf_ocr.py
+++ b/extract-text-from-pdf-ocr/scripts/extract_text_from_pdf_ocr.py
@@ -51,7 +51,7 @@ logging.info(f"Output folder: {path_output}")
 logging.info("Searching for PDF files in the input folder...")
 
 # List and count PDF files
-input_pdf_files = [f for f in os.listdir(path_input) if f.endswith(".pdf")]
+input_pdf_files = [f for f in os.listdir(path_input) if f.lower().endswith(".pdf")]
 input_num_pdfs = len(input_pdf_files)
 logging.info(f"Found {input_num_pdfs} PDF file(s) to process.")
 


### PR DESCRIPTION
Nice code, but I would make a small change on line 54 as PDF file extensions can be both upper and lower case.